### PR TITLE
Update setup README to correct GridLAB-D commands

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -20,7 +20,7 @@ Installing GridLAB-D with HELICS on Linux and MacOS:
 -   Type `autoreconf -if`
 -   Then run the following
     ```
-    ./configure --prefix=/path/to/gridlabd/install --with-helics=/path/to/helics/install --enable-silent-rules "CFLAGS=-g -O0 -w" "CXXFLAGS=-g -O0 -w -std=c++11" "LDFLAGS=-g -O0 -w"
+    ./configure --prefix=/path/to/gridlabd/install --with-helics=/path/to/helics/install --enable-silent-rules "CFLAGS=-g -O0 -w" "CXXFLAGS=-g -O0 -w -std=c++14" "LDFLAGS=-g -O0 -w"
     ```
 -   For Sierra users it is important that you compile HELICS and
     GridLAB-D and there prereqs with gcc and not clang. There is an


### PR DESCRIPTION
As noted in a now closed [issue](https://github.com/gridlab-d/gridlab-d/issues/1148), when attempting to compile GridLAB-D with HELICS support, it may fail with the currently suggested ./configure arguments. Setting the C++ standard to 14 seems to correct this.