### PR TITLE
Update tutorial 2 to v2 helics

### DIFF
--- a/tutorials/2-DistributionFederation-HELICSRunner/README.md
+++ b/tutorials/2-DistributionFederation-HELICSRunner/README.md
@@ -2,21 +2,38 @@
 
 **GridLAB-D + PythonCombinationFederate**
 
-Run in terminal 1
+The `helics-cli run` does not respect the `broker: true` flag. This is a known issue, and a fix is currently being implemented. 
+
+Because of this, to run this example you need to create the broker manually. Once this issue is fixed, getting this example running will only require the commands in terminal 2. 
+
+### Create Broker Manually
+
+Run in terminal 1 
 
 ```bash
 cd /path/to/HELICS-Tutorial/tutorials/2-DistributionFederation-HELICSRunner/
+helics_broker -f 2 --loglevel=3 --name=mainbroker
+```
+
+### Run the co-simulation
+
+Run in terminal 2
+
+```bash
+cd /path/to/HELICS-Tutorial/tutorials/2-DistributionFederation-ManualStart/
 helics run --path config.json
 ```
 
-Run in terminal 2
+### Monitor outputs (optional)
+
+Run in terminal 3
 
 ```bash
 cd /path/to/HELICS-Tutorial/tutorials/2-DistributionFederation-ManualStart/
 tail -f ./PythonCombinationFederate.log
 ```
 
-Run in terminal 3
+Run in terminal 4
 
 ```bash
 cd /path/to/HELICS-Tutorial/tutorials/2-DistributionFederation-ManualStart/

--- a/tutorials/2-DistributionFederation-HELICSRunner/federate1.py
+++ b/tutorials/2-DistributionFederation-HELICSRunner/federate1.py
@@ -38,7 +38,7 @@ def create_federate(deltat=1.0, fedinitstring="--federates=1"):
 
     return fed
 
-def destroy_federate(fed, broker):
+def destroy_federate(fed, broker=None):
     status = h.helicsFederateFinalize(fed)
 
     status, state = h.helicsFederateGetState(fed)

--- a/tutorials/2-DistributionFederation-HELICSRunner/federate1.py
+++ b/tutorials/2-DistributionFederation-HELICSRunner/federate1.py
@@ -3,6 +3,10 @@ import helics as h
 import random
 import logging
 
+
+helicsversion = h.helicsGetVersion()
+print("Federate 1: HELICS version = {}".format(helicsversion))
+
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 logger.setLevel(logging.DEBUG)
@@ -20,24 +24,17 @@ def create_broker():
 
 def create_federate(deltat=1.0, fedinitstring="--federates=1"):
 
-    fedinfo = h.helicsFederateInfoCreate()
+    fedinfo = h.helicsCreateFederateInfo()
 
-    status = h.helicsFederateInfoSetFederateName(fedinfo, "Combination Federate")
-    assert status == 0
+    status = h.helicsFederateInfoSetCoreName(fedinfo, "Combination Federate")
 
-    status = h.helicsFederateInfoSetCoreTypeFromString(fedinfo, "zmq")
-    assert status == 0
+    h.helicsFederateInfoSetCoreTypeFromString(fedinfo, "zmq")
 
     status = h.helicsFederateInfoSetCoreInitString(fedinfo, fedinitstring)
-    assert status == 0
 
-    status = h.helicsFederateInfoSetTimeDelta(fedinfo, deltat)
-    assert status == 0
+    status = h.helicsFederateInfoSetTimeProperty(fedinfo, h.helics_property_time_delta, deltat)
 
-    status = h.helicsFederateInfoSetLoggingLevel(fedinfo, 1)
-    assert status == 0
-
-    fed = h.helicsCreateCombinationFederate(fedinfo)
+    fed = h.helicsCreateCombinationFederate("Combination Federate", fedinfo)
 
     return fed
 
@@ -57,16 +54,19 @@ def destroy_federate(fed, broker):
 
 def main():
 
-    # broker = create_broker()
     fed = create_federate()
 
-    pubid = h.helicsFederateRegisterGlobalTypePublication (fed, "TransmissionSim/B2Voltage", h.HELICS_DATA_TYPE_COMPLEX, "")
-    subid = h.helicsFederateRegisterSubscription (fed, "DistributionSim_B2_G_1/totalLoad", "complex", "")
+    # Register publication
+    pubid = h.helicsFederateRegisterGlobalPublication(fed, "TransmissionSim/B2Voltage", h.helics_data_type_complex, "")
+    
+    # Register subscription
+    subid = h.helicsFederateRegisterSubscription(fed, "DistributionSim_B2_G_1/totalLoad", "")
+    
+    # Register endpoint
     epid = h.helicsFederateRegisterEndpoint(fed, "ep1", None)
 
-    h.helicsSubscriptionSetDefaultComplex(subid, 0, 0)
-
-    h.helicsFederateEnterExecutionMode(fed)
+    # Enter execution mode
+    h.helicsFederateEnterExecutingMode(fed)
 
     hours = 1
     seconds = int(60 * 60 * hours)
@@ -78,24 +78,19 @@ def main():
         status = h.helicsPublicationPublishComplex(pubid, c.real, c.imag)
         # status = h.helicsEndpointSendEventRaw(epid, "fixed_price", 10, t)
         while grantedtime < t:
-            status, grantedtime = h.helicsFederateRequestTime (fed, t)
+            grantedtime = h.helicsFederateRequestTime(fed, t)
         time.sleep(1)
-        status, rValue, iValue = h.helicsSubscriptionGetComplex(subid)
+        rValue, iValue = h.helicsInputGetComplex(subid)
         logger.info("Python Federate grantedtime = {}".format(grantedtime))
-        logger.info("Load value = {} MW".format(complex(rValue, iValue)/1000))
+        logger.info("Load value = {} MVA".format(complex(rValue, iValue)/1000))
 
     t = 60 * 60 * 24
     while grantedtime < t:
-        status, grantedtime = h.helicsFederateRequestTime (fed, t)
+        grantedtime = h.helicsFederateRequestTime (fed, t)
     logger.info("Destroying federate")
     destroy_federate(fed)
-
 
 if __name__ == "__main__":
 
     main()
     logger.info("Done!")
-
-
-
-


### PR DESCRIPTION
Tutorial 2 required modifications to the python federate `federate1.py` to work with HELICS v2 functions. These functions are updated and tested, based on the Tutorial 1 modifications. 

Tutorials 3-5 not yet updated in this way. 

Closes #10 